### PR TITLE
Fix buffered logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,6 @@ RUN apk add --update --no-cache py3-pip && \
 
 ADD restic_mon.py /restic_mon.py
 
+ENV PYTHONUNBUFFERED=1
+
 CMD /restic_mon.py

--- a/restic_mon.py
+++ b/restic_mon.py
@@ -3,7 +3,6 @@
 import boto3
 from datetime import datetime
 import time
-import sys
 import os
 import re
 from socketserver import ThreadingMixIn
@@ -253,7 +252,6 @@ def main():
     try:
         while 1:
             server.handle_request()
-            sys.stdout.flush()
     except KeyboardInterrupt:
         print("\nShutting down server per users request.")
 

--- a/restic_mon.py
+++ b/restic_mon.py
@@ -253,6 +253,7 @@ def main():
     try:
         while 1:
             server.handle_request()
+            sys.stdout.flush()
     except KeyboardInterrupt:
         print("\nShutting down server per users request.")
 

--- a/restic_mon.py
+++ b/restic_mon.py
@@ -252,7 +252,6 @@ def main():
     print("Starting webserver on port 8080")
     try:
         while 1:
-            sys.stdout.flush()
             server.handle_request()
     except KeyboardInterrupt:
         print("\nShutting down server per users request.")


### PR DESCRIPTION
When running the script in a kubernetes environment, some time has passed between the script starting up and the cube-probes showing up in the logs.
When the kube-probes were finally logged, a batch of logs appeared all at once with some older probes.

Setting the `PYTHONUNBUFFERED` environment variable in the `Dockerfile` solves this by disabling the buffering of log lines.